### PR TITLE
Fix unreachable macro error message in trait example

### DIFF
--- a/crates/cdk-ansible/src/deploy/types.rs
+++ b/crates/cdk-ansible/src/deploy/types.rs
@@ -174,7 +174,7 @@ mod tests {
             ExePlay::Parallel(_) => {
                 // OK
             }
-            _ => unreachable!("exe_play should be ExeParallel"),
+            _ => unreachable!("exe_play should be ExeSequential"),
         }
     }
 }


### PR DESCRIPTION
```
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct `unreachable!` error message in `test_into_parallel` from 'ExeParallel' to 'ExeSequential'.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user reported this as a copy-paste error, stating the code was testing for sequential execution. While the `test_into_parallel` function currently asserts for `ExePlay::Parallel` (making the original message logically consistent with its current implementation), this change directly addresses the reported bug.
```