### PR TITLE
feat(cdk-ansible): wait for all parallel tasks to complete before checking results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 
@@ -926,6 +927,26 @@ dependencies = [
  "cdk-ansible",
  "indexmap",
  "serde_json",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = { version = "1.0.138", features = ["preserve_order"] }
 shlex = "1.3.0"
 syn = { version = "2.0.90", features = ["full"] }
 tempfile = { version = "3" }
+thiserror = "2.0.12"
 tokio = { version = "1", features = ["full"] }
 toml = "0.9.2"
 toml_edit = "0.23.2"

--- a/cdk-ansible.code-workspace
+++ b/cdk-ansible.code-workspace
@@ -43,7 +43,6 @@
     },
     "search.exclude": {
       "**/target/": true,
-      "crates/cdkam/**": true,
     },
     "rust-analyzer.cargo.extraEnv": {
       "CDK_ANSIBLE_COMMIT_HASH": "dummy_hash",

--- a/crates/cdk-ansible/Cargo.toml
+++ b/crates/cdk-ansible/Cargo.toml
@@ -26,4 +26,5 @@ serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 tokio.workspace = true

--- a/examples/simple-sample/src/bin/l2.rs
+++ b/examples/simple-sample/src/bin/l2.rs
@@ -70,7 +70,44 @@ impl LazyPlayL2 for Sample1LazyPlayL2Helper {
                     name: name.clone(),
                     hosts: HostsL2::new(vec![Arc::clone(&hp.localhost) as _]),
                     options: PlayOptions::default(),
-                    tasks: create_tasks_helper(Arc::clone(&hp.localhost) as _, 2)?,
+                    tasks: vec![::cdk_ansible::Task {
+                        name: "sleep".into(),
+                        options: TaskOptions {
+                            changed_when: OptU::Some(false.into()),
+                            // failed_when: OptU::Some("true".into()), // interruption test
+                            ..Default::default()
+                        },
+                        command: Box::new(::sample_cdkam_ansible::builtin::command::Module {
+                            module: ::sample_cdkam_ansible::builtin::command::Args {
+                                options: ::sample_cdkam_ansible::builtin::command::Opt {
+                                    cmd: OptU::Some("sleep 1".into()),
+                                    ..Default::default()
+                                },
+                            },
+                        }),
+                    }],
+                }
+                .into(),
+                PlayL2 {
+                    name: name.clone(),
+                    hosts: HostsL2::new(vec![Arc::clone(&hp.localhost) as _]),
+                    options: PlayOptions::default(),
+                    tasks: vec![::cdk_ansible::Task {
+                        name: "sleep".into(),
+                        options: TaskOptions {
+                            changed_when: OptU::Some(false.into()),
+                            // failed_when: OptU::Some("true".into()), // interruption test
+                            ..Default::default()
+                        },
+                        command: Box::new(::sample_cdkam_ansible::builtin::command::Module {
+                            module: ::sample_cdkam_ansible::builtin::command::Args {
+                                options: ::sample_cdkam_ansible::builtin::command::Opt {
+                                    cmd: OptU::Some("sleep 1".into()),
+                                    ..Default::default()
+                                },
+                            },
+                        }),
+                    }],
                 }
                 .into(),
                 ExePlayL2::Sequential(vec![


### PR DESCRIPTION

- Add `thiserror` crate for custom error type management
- Update error handling in `deploy.rs` to use `DeployL2Error` for better clarity and structure
- Enhance parallel execution to aggregate and report all deployment errors